### PR TITLE
Fix JWT secret loading bug

### DIFF
--- a/internal/usecase/user_usecase.go
+++ b/internal/usecase/user_usecase.go
@@ -82,7 +82,10 @@ func (u *userUsecase) Login(ctx context.Context, req *dto.LoginRequest) (*dto.Lo
 	}
 
 	// Generate token
-	token := pkg.GenerateToken(user.ID) // Pastikan user.ID bertipe int64
+	token, err := pkg.GenerateToken(user.ID)
+	if err != nil {
+		return nil, err
+	}
 
 	// Buat response
 	resp := &dto.LoginResponse{

--- a/test/pkg/jwt_test.go
+++ b/test/pkg/jwt_test.go
@@ -1,0 +1,21 @@
+package pkg_test
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"pt-xyz-multifinance/pkg"
+)
+
+func TestGenerateAndValidateToken_UsesRuntimeSecret(t *testing.T) {
+	os.Setenv("JWT_SECRET", "secret1")
+	token, err := pkg.GenerateToken("user123")
+	assert.NoError(t, err)
+	assert.NotEmpty(t, token)
+
+	// change secret after token generation
+	os.Setenv("JWT_SECRET", "secret2")
+	_, err = pkg.ValidateToken(token)
+	assert.Error(t, err)
+}


### PR DESCRIPTION
## Summary
- load JWT secret from environment at runtime
- propagate errors from token generation
- update login flow to handle token generation errors
- add unit test ensuring secret is read at runtime

## Testing
- `go mod tidy` *(fails: proxy access blocked)*
- `go test ./...` *(fails: missing go.sum due to failed dependencies)*

------
https://chatgpt.com/codex/tasks/task_b_685a0e1a62d08333816a7d8fffdd083f